### PR TITLE
Alternative method for generating word timestamps

### DIFF
--- a/alternative.py
+++ b/alternative.py
@@ -1,4 +1,5 @@
 from lhotse import CutSet, RecordingSet, align_with_torchaudio, annotate_with_whisper, MonoCut
+from pydub import AudioSegment
 from tqdm import tqdm
 
 
@@ -16,7 +17,11 @@ def convert_cut(cut: MonoCut):
     return results
 
 
-recordings = RecordingSet.from_dir("./", pattern="audio.mp3")
+sound = AudioSegment.from_mp3("audio.mp3")
+sound = sound.set_channels(1)
+sound.export("audio.wav", format="wav")
+
+recordings = RecordingSet.from_dir("./", pattern="audio.wav")
 
 cuts = list(annotate_with_whisper(recordings))
 cuts_aligned = align_with_torchaudio(cuts)

--- a/alternative.py
+++ b/alternative.py
@@ -1,0 +1,30 @@
+from lhotse import CutSet, RecordingSet, align_with_torchaudio, annotate_with_whisper, MonoCut
+from tqdm import tqdm
+
+
+def convert_cut(cut: MonoCut):
+    results = []
+    for supervision in cut.supervisions:
+        words = supervision.text.split()
+        for word, alignment_item in zip(words, supervision.alignment['word']):
+            results.append({
+                "word": word,
+                "confidence": alignment_item.score,
+                "start": alignment_item.start,
+                "end": alignment_item.start + alignment_item.duration
+            })
+    return results
+
+
+recordings = RecordingSet.from_dir("./", pattern="audio.mp3")
+
+cuts = list(annotate_with_whisper(recordings))
+cuts_aligned = align_with_torchaudio(cuts)
+
+results = []
+for cut in tqdm(cuts_aligned, desc="Progress"):
+    # convert to list of dictionaries {word,confidence,start,end}
+    results.extend(convert_cut(cut))
+
+for result in results:
+    print(result)


### PR DESCRIPTION
Solves https://github.com/zhangjoe99/CustomWhisper/issues/6

This alternative method still transcribes the audio using whisper, but uses pytorchaudio rather than stable-ts to align the words with timestamps. 

One slight difference is that the audio will have to be converted to mono channel. 
